### PR TITLE
Fixed malformed .ini file and removed obsolete libraries

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,16 +17,18 @@ framework = arduino
 platform = https://github.com/tsandmann/platform-teensy.git
 board = teensy41
 
-framework = arduino
 lib_deps =
 ;	https://github.com/greiman/FreeRTOS-Arduino.git this is an old version (10 years)
 ; using this instead;
 	https://github.com/tsandmann/freertos-teensy.git
 	teamsunride/Arduino-LSM6DSO32@^1.1.2
-	adafruit/Adafruit BME280 Library@^2.3.0
-	adafruit/Adafruit Unified Sensor@^1.1.15
+	wollewald/ICM20948_WE@^1.2.8
+	https://github.com/sparkfun/SparkFun_u-blox_GNSS_v3.git
+	https://github.com/RobTillaart/MS5611.git
+	jgromes/RadioLib@^7.5.0
 	eigen
 	arduino-libraries/Servo@^1.3.0
+	https://github.com/PaulStoffregen/PWMServo.git
   
 build_flags =
 	-DBUILD_DEBUG
@@ -35,16 +37,6 @@ build_flags =
 	-DUSB_SERIAL
   -D TEENSY_4_1
   -I.pio/libdeps/teensy41/Eigen
-    
-lib_deps = 
-	https://github.com/tsandmann/freertos-teensy.git
-	teamsunride/Arduino-LSM6DSO32@^1.1.2
-	adafruit/Adafruit BME280 Library@^2.3.0
-	adafruit/Adafruit Unified Sensor@^1.1.15
-	wollewald/ICM20948_WE@^1.2.8
-	https://github.com/sparkfun/SparkFun_u-blox_GNSS_v3.git
-	https://github.com/RobTillaart/MS5611.git
-	jgromes/RadioLib@^7.5.0
   
 test_filter = embedded/*
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -21,7 +21,6 @@ lib_deps =
 ;	https://github.com/greiman/FreeRTOS-Arduino.git this is an old version (10 years)
 ; using this instead;
 	https://github.com/tsandmann/freertos-teensy.git
-	teamsunride/Arduino-LSM6DSO32@^1.1.2
 	wollewald/ICM20948_WE@^1.2.8
 	https://github.com/sparkfun/SparkFun_u-blox_GNSS_v3.git
 	https://github.com/RobTillaart/MS5611.git
@@ -61,7 +60,6 @@ board = teensy41
 framework = arduino
 lib_deps =
 	https://github.com/tsandmann/freertos-teensy.git
-	teamsunride/Arduino-LSM6DSO32@^1.1.2
 	wollewald/ICM20948_WE@^1.2.8
 	https://github.com/sparkfun/SparkFun_u-blox_GNSS_v3.git
 	https://github.com/RobTillaart/MS5611.git

--- a/platformio.ini
+++ b/platformio.ini
@@ -28,7 +28,6 @@ lib_deps =
 	jgromes/RadioLib@^7.5.0
 	eigen
 	arduino-libraries/Servo@^1.3.0
-	https://github.com/PaulStoffregen/PWMServo.git
   
 build_flags =
 	-DBUILD_DEBUG

--- a/platformio.ini
+++ b/platformio.ini
@@ -62,8 +62,10 @@ framework = arduino
 lib_deps =
 	https://github.com/tsandmann/freertos-teensy.git
 	teamsunride/Arduino-LSM6DSO32@^1.1.2
-	adafruit/Adafruit BME280 Library@^2.3.0
-	adafruit/Adafruit Unified Sensor@^1.1.15
+	wollewald/ICM20948_WE@^1.2.8
+	https://github.com/sparkfun/SparkFun_u-blox_GNSS_v3.git
+	https://github.com/RobTillaart/MS5611.git
+	jgromes/RadioLib@^7.5.0
 	eigen
 	arduino-libraries/Servo@^1.3.0
 build_flags =


### PR DESCRIPTION
The .ini file had some problems with duplicate fields, resulting in the project failing to initialize.
While I was at it I removed some of the library dependencies that are not needed anymore (BME280, LSM6DSO32 etc.)